### PR TITLE
fixes #12 Added basic implementation of UIManager::setChildren method.

### DIFF
--- a/ReactQt/runtime/src/reactuimanager.cpp
+++ b/ReactQt/runtime/src/reactuimanager.cpp
@@ -126,12 +126,12 @@ void ReactUIManager::setChildren
   const QList<int>& childrenTags
 )
 {
-  //This is a simple implementation which fixes a broken example. It's not properly tested and may need revisiting
-  QList<int> newIndices;
+  //TODO: This is a simple implementation which fixes a broken example. It's not properly tested and may need revisiting
+  QList<int> indices;
   foreach(int i, childrenTags) {
-     newIndices.append(i + 1);
+    indices.append(1); //same Z order for all items
   }
-  manageChildren(containerReactTag, QList<int>(), QList<int>(), childrenTags, newIndices,  QList<int>());
+  manageChildren(containerReactTag, QList<int>(), QList<int>(), childrenTags, indices,  QList<int>());
 }
 
 void ReactUIManager::manageChildren

--- a/ReactQt/runtime/src/reactuimanager.cpp
+++ b/ReactQt/runtime/src/reactuimanager.cpp
@@ -120,6 +120,20 @@ void ReactUIManager::updateView
   m_bridge->visualParent()->polish();
 }
 
+void ReactUIManager::setChildren
+(
+  int containerReactTag,
+  const QList<int>& childrenTags
+)
+{
+  //This is a simple implementation which fixes a broken example. It's not properly tested and may need revisiting
+  QList<int> newIndices;
+  foreach(int i, childrenTags) {
+     newIndices.append(i + 1);
+  }
+  manageChildren(containerReactTag, QList<int>(), QList<int>(), childrenTags, newIndices,  QList<int>());
+}
+
 void ReactUIManager::manageChildren
 (
   int containerReactTag,

--- a/ReactQt/runtime/src/reactuimanager.h
+++ b/ReactQt/runtime/src/reactuimanager.h
@@ -48,6 +48,9 @@ class ReactUIManager
                                   const QList<int>& addChildReactTags,
                                   const QList<int>& addAtIndices,
                                   const QList<int>& removeAtIndices);
+  Q_INVOKABLE void setChildren(int containerReactTag,
+                               const QList<int>& childrenTags);
+
   Q_INVOKABLE void replaceExistingNonRootView(int reactTag, int newReactTag);
   Q_INVOKABLE void measureLayout(int reactTag,
                                  int ancestorReactTag,


### PR DESCRIPTION
(fixes the broken TicTacToe example)

Test:
 With this change the UI is properly displayed, but click handling of items is stil broken (another missing thing).
 To temporary fix that for testing you can  comment out JSTimersExecution usage from  ReactQt/runtime/src/reacttiming.cpp file.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. In other words, a test plan is *required*. Bonus points for screenshots and videos!

Please read the Contribution Guidelines at https://github.com/facebook/react-native/blob/master/CONTRIBUTING.md to learn more about contributing to React Native.

Happy contributing!
-->
