### PR TITLE
fixes #18 Fixed the issue with not registered JSTimersExecution module.

### DIFF
--- a/ReactQt/runtime/src/reacttiming.cpp
+++ b/ReactQt/runtime/src/reacttiming.cpp
@@ -91,7 +91,7 @@ void ReactTiming::createTimer
   if (duration == 0 && !repeats) {
     // XXX: enqueueJSCall should enqueue
     QTimer::singleShot(0, [=] {
-        m_bridge->enqueueJSCall("JSTimersExecution", "callTimers", QVariantList{QVariantList{callbackId}});
+        m_bridge->enqueueJSCall("JSTimers", "callTimers", QVariantList{QVariantList{callbackId}});
       });
     return;
   }
@@ -101,7 +101,7 @@ void ReactTiming::createTimer
   timer->setSingleShot(!repeats);
   QObject::connect(timer, &QTimer::timeout, [=]() {
       if (m_bridge)
-        m_bridge->enqueueJSCall("JSTimersExecution", "callTimers", QVariantList{QVariantList{callbackId}});
+        m_bridge->enqueueJSCall("JSTimers", "callTimers", QVariantList{QVariantList{callbackId}});
       if (!repeats)
         deleteTimer(callbackId);
     });


### PR DESCRIPTION
`JSTimersExecution` module was merged into `JSTimers`, so using that one.