### PR TITLE
refs #5 - CicleCi build based on Qt 5.9.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: ~/repo
 
     steps:
-      - run: echo 'export PATH=/opt/qt55/bin/:$PATH' >> $BASH_ENV
+      - run: echo 'export PATH=/opt/qt59/bin/:$PATH' >> $BASH_ENV
 
       - checkout
 
@@ -15,11 +15,12 @@ jobs:
       - run: |
           sudo apt-get update -y
           sudo apt-get install -y software-properties-common
-          sudo add-apt-repository -y ppa:beineri/opt-qt551-trusty
+          sudo add-apt-repository -y ppa:beineri/opt-qt591-trusty
           sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
           sudo apt-get -qy update
-          sudo apt-get install -y dbus xvfb curl cmake qt55base qt55webkit qt55graphicaleffects qt55quick1 qt55quickcontrols qt55websockets qt55declarative mesa-common-dev libgl1-mesa-dev
-          echo "/opt/qt55/bin/qt55-env.sh" >> ~/.circlerc
+          sudo apt-get install -y dbus xvfb curl cmake mesa-common-dev \
+              qt59base qt59graphicaleffects qt59quickcontrols2 qt59declarative 
+          echo "/opt/qt59/bin/qt59-env.sh" >> ~/.circlerc
 
       # Install node
       - run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.2.2)
 
 project(react-native-ubuntu)
 


### PR DESCRIPTION
- CircleCI build script updated to use Qt 5.9.1
- Sets minimum supported version of CMake to 3.2.2 (CMake v.2.8 has some issues with embedding of Qt5 qrc resources into binaries)