### PR TITLE
fixes #35

### DIFF
--- a/ReactQt/runtime/src/reactbridge.cpp
+++ b/ReactQt/runtime/src/reactbridge.cpp
@@ -345,7 +345,7 @@ void ReactBridge::initModules() {
         ReactModuleInterface* module = qobject_cast<ReactModuleInterface*>(o);
         if (module != nullptr) {
             module->setBridge(this);
-            ReactModuleData* moduleData = new ReactModuleData(o);
+            ReactModuleData* moduleData = new ReactModuleData(o, d->modules.size());
             d->modules.insert(moduleData->id(), moduleData);
         } else {
             qWarning() << "A module loader exported an invalid module";

--- a/ReactQt/runtime/src/reactbridge.cpp
+++ b/ReactQt/runtime/src/reactbridge.cpp
@@ -140,7 +140,6 @@ void ReactBridge::reload() {
         delete md;
     }
     d->modules.clear();
-
     initModules();
     injectModules();
     loadSource();

--- a/ReactQt/runtime/src/reactmoduledata.cpp
+++ b/ReactQt/runtime/src/reactmoduledata.cpp
@@ -128,3 +128,7 @@ ReactModuleMethod* ReactModuleData::method(int id) const {
 ReactViewManager* ReactModuleData::viewManager() const {
     return qobject_cast<ReactModuleInterface*>(d_func()->moduleImpl)->viewManager();
 }
+
+void ReactModuleData::resetModuleIdCounter() {
+    nextModuleId = 0;
+}

--- a/ReactQt/runtime/src/reactmoduledata.cpp
+++ b/ReactQt/runtime/src/reactmoduledata.cpp
@@ -20,8 +20,8 @@
 #include "reactmoduleinterface.h"
 #include "reactmodulemethod.h"
 
-namespace {
-static int nextModuleId = 0;
+namespace
+{
 // TODO: sort out all the issues around methodsToExport
 
 QList<ReactModuleMethod*> buildMethodList(QObject* moduleImpl) {
@@ -72,9 +72,11 @@ public:
     QList<ReactModuleMethod*> methods;
 };
 
-ReactModuleData::ReactModuleData(QObject* moduleImpl) : d_ptr(new ReactModuleDataPrivate) {
+ReactModuleData::ReactModuleData(QObject* moduleImpl, int id)
+    : d_ptr(new ReactModuleDataPrivate)
+{
     Q_D(ReactModuleData);
-    d->id = nextModuleId++;
+    d->id = id;
     d->moduleImpl = moduleImpl;
     d->constants = buildConstantMap(moduleImpl);
     d->methods = buildMethodList(moduleImpl);
@@ -127,8 +129,4 @@ ReactModuleMethod* ReactModuleData::method(int id) const {
 
 ReactViewManager* ReactModuleData::viewManager() const {
     return qobject_cast<ReactModuleInterface*>(d_func()->moduleImpl)->viewManager();
-}
-
-void ReactModuleData::resetModuleIdCounter() {
-    nextModuleId = 0;
 }

--- a/ReactQt/runtime/src/reactmoduledata.h
+++ b/ReactQt/runtime/src/reactmoduledata.h
@@ -25,7 +25,7 @@ class ReactModuleData {
     Q_DECLARE_PRIVATE(ReactModuleData)
 
 public:
-    ReactModuleData(QObject* moduleImpl);
+    ReactModuleData(QObject* moduleImpl, int id);
     ~ReactModuleData();
 
     int id() const;
@@ -37,7 +37,6 @@ public:
 
     ReactViewManager* viewManager() const;
 
-  static void resetModuleIdCounter();
 private:
     QScopedPointer<ReactModuleDataPrivate> d_ptr;
 };

--- a/ReactQt/runtime/src/reactmoduledata.h
+++ b/ReactQt/runtime/src/reactmoduledata.h
@@ -37,6 +37,7 @@ public:
 
     ReactViewManager* viewManager() const;
 
+  static void resetModuleIdCounter();
 private:
     QScopedPointer<ReactModuleDataPrivate> d_ptr;
 };


### PR DESCRIPTION
Fixed crash on Redbox reload

Description:  
The crash was caused by the mismatch of module id and sequential index  - https://github.com/status-im/react-native-linux/blob/react-native-qt/ReactQt/runtime/src/reactbridge.cpp#L362 
On reload the list of modules was being cleared but the IDs were incremented from the last ID. 
So, on reload resetting the nextModuleId. 

Test: 
.Add a syntax error in Examples/TicTacToe/TicTacToe.js , run the example. 
=>Make sure Redbox is displayed 
. Fix the error in js file and save. 
. Press Reload on Redbox
=>Make sure TicTacToe is properly displayed. 