### PR TITLE
Now you don't have to specify <Button> size explicitly

### DIFF
--- a/Examples/Button/ButtonApp.js
+++ b/Examples/Button/ButtonApp.js
@@ -34,7 +34,6 @@ export default class ButtonReactNative extends Component {
            title="Click me"
            color={this.state.buttonColor}
            accessibilityLabel="Learn more about this purple button"
-           style={{width:120, height: 50}}
         >
         </Button>
     );

--- a/RNTester/js/RNTesterList.ubuntu.js
+++ b/RNTester/js/RNTesterList.ubuntu.js
@@ -33,6 +33,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     key: 'ButtonExample',
     module: require('./ButtonExample'),
   },
+  {
+    key: 'LayoutExample',
+    module: require('./LayoutExample'),
+  },
 ];
 
 const APIExamples: Array<RNTesterExample> = [

--- a/ReactQt/runtime/src/qml/ReactButton.qml
+++ b/ReactQt/runtime/src/qml/ReactButton.qml
@@ -7,7 +7,7 @@ Button {
 
     property string p_accessibilityLabel
     property string p_title
-    property string p_color
+    property string p_color: "#e0e0e0"
     property bool p_disabled: false
     property bool p_onPress: false
     property string p_testID
@@ -17,10 +17,13 @@ Button {
     text: p_title
     objectName: p_testID
 
+    implicitHeight: 40
+    implicitWidth: 100
+
     background: Rectangle {
-        anchors.fill: parent
-        color: buttonRoot.p_color
-    }
+            color: buttonRoot.down ? Qt.darker(buttonRoot.p_color, 1.2) : buttonRoot.p_color
+            visible: !buttonRoot.flat || buttonRoot.down || buttonRoot.checked || buttonRoot.highlighted
+        }
 
     onPressed: buttonManager.sendPressedNotificationToJs(buttonRoot)
 }

--- a/ReactQt/runtime/src/qml/ReactButton.qml
+++ b/ReactQt/runtime/src/qml/ReactButton.qml
@@ -21,9 +21,9 @@ Button {
     implicitWidth: 100
 
     background: Rectangle {
-            color: buttonRoot.down ? Qt.darker(buttonRoot.p_color, 1.2) : buttonRoot.p_color
-            visible: !buttonRoot.flat || buttonRoot.down || buttonRoot.checked || buttonRoot.highlighted
-        }
+        color: buttonRoot.down ? Qt.darker(buttonRoot.p_color, 1.2) : buttonRoot.p_color
+        visible: !buttonRoot.flat || buttonRoot.down || buttonRoot.checked || buttonRoot.highlighted
+    }
 
     onPressed: buttonManager.sendPressedNotificationToJs(buttonRoot)
 }

--- a/ReactQt/runtime/src/qml/ReactView.qml
+++ b/ReactQt/runtime/src/qml/ReactView.qml
@@ -6,6 +6,9 @@ React.Item {
 
     property var p_transformMatrix;
     property var viewManager: null
+    property string p_nativeID
+
+    objectName: p_nativeID
 
     onP_transformMatrixChanged: viewManager.manageTransforMatrix(p_transformMatrix, viewRoot)
 }

--- a/ReactQt/runtime/src/reactbuttonmanager.cpp
+++ b/ReactQt/runtime/src/reactbuttonmanager.cpp
@@ -21,6 +21,7 @@
 #include "reactbridge.h"
 #include "reactbuttonmanager.h"
 #include "reactevents.h"
+#include "reactflexlayout.h"
 #include "reactpropertyhandler.h"
 
 const QString EVENT_ONPRESSED = "onPress";
@@ -59,6 +60,13 @@ QString ReactButtonManager::qmlComponentFile() const {
 void ReactButtonManager::configureView(QQuickItem* view) const {
     ReactViewManager::configureView(view);
     view->setProperty("buttonManager", QVariant::fromValue((QObject*)this));
+    if (shouldLayout()) {
+        // In React Native <Button> should be visible even if we didn't
+        // specify height and width. So we tell flex layout system to take
+        // into account implicit values in ReactButton.qml
+        ReactFlexLayout::get(view)->setQmlImplicitWidth(true);
+        ReactFlexLayout::get(view)->setQmlImplicitHeight(true);
+    }
 }
 
 #include "reactbuttonmanager.moc"

--- a/ReactQt/runtime/src/reactflexlayout.cpp
+++ b/ReactQt/runtime/src/reactflexlayout.cpp
@@ -309,7 +309,6 @@ QDebug operator<<(QDebug debug, const ReactFlexLayoutPrivate* p) {
 
 ReactFlexLayout::ReactFlexLayout(QObject* parent) : QObject(parent), d_ptr(new ReactFlexLayoutPrivate(this)) {
     Q_D(ReactFlexLayout);
-    // qDebug() << "Layout created for: " << parent;
     d->qmlAnchors = false;
     d->qmlImplicitWidth = false;
     d->qmlImplicitHeight = false;

--- a/ReactQt/runtime/src/reactflexlayout.cpp
+++ b/ReactQt/runtime/src/reactflexlayout.cpp
@@ -164,10 +164,10 @@ public:
             p->cssNode->style.dimensions[CSS_HEIGHT] = p->item->height();
         }
         if (p->qmlImplicitWidth) {
-            p->cssNode->style.dimensions[CSS_WIDTH] = QQmlProperty(p->item, "implictWidth").read().value<double>();
+            p->cssNode->style.dimensions[CSS_WIDTH] = QQmlProperty(p->item, "implicitWidth").read().value<double>();
         }
         if (p->qmlImplicitHeight) {
-            p->cssNode->style.dimensions[CSS_HEIGHT] = QQmlProperty(p->item, "implictHeight").read().value<double>();
+            p->cssNode->style.dimensions[CSS_HEIGHT] = QQmlProperty(p->item, "implicitHeight").read().value<double>();
         }
 
         for (auto& c : p->children) {
@@ -309,6 +309,7 @@ QDebug operator<<(QDebug debug, const ReactFlexLayoutPrivate* p) {
 
 ReactFlexLayout::ReactFlexLayout(QObject* parent) : QObject(parent), d_ptr(new ReactFlexLayoutPrivate(this)) {
     Q_D(ReactFlexLayout);
+    // qDebug() << "Layout created for: " << parent;
     d->qmlAnchors = false;
     d->qmlImplicitWidth = false;
     d->qmlImplicitHeight = false;


### PR DESCRIPTION
- Implicit height and width added to Button
- ReactButtonManager now instructs flex layout that implicit height and width of ReactButton.qml should be taken into account when calculating layout size.
- Default color added to Button
- Button becomes darker when pressed
- p_nativeID property added to ReactView, to make inspection in GammaRay easier