### PR TITLE
refs #75 - Unit test JS exception; Reload to specified JS bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
 
     steps:
       - run: echo 'export PATH=/opt/qt59/bin/:$PATH' >> $BASH_ENV
+      - run: echo 'export QTDIR=/opt/qt59' >> $BASH_ENV
+      - run: echo 'export LD_LIBRARY_PATH=/opt/qt59/lib/x86_64-linux-gnu:/opt/qt59/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
+      - run: echo 'export PKG_CONFIG_PATH=/opt/qt59/lib/pkgconfig:$PKG_CONFIG_PATH' >> $BASH_ENV
 
       - checkout
 

--- a/IntegrationTests/TestJSException.js
+++ b/IntegrationTests/TestJSException.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ * @providesModule TestJSException
+ */
+'use strict';
+
+var React = require('react');
+var createReactClass = require('create-react-class');
+var ReactNative = require('react-native');
+
+var {
+  AppRegistry,
+  Text,
+  View,
+} = ReactNative;
+
+var TestJSException = createReactClass({
+  displayName: 'TestJSException',
+
+  componentDidMount() {
+    throw new Error('Exception on componentDidMount. File TestJSException.js');
+  },
+
+  render() {
+    return (
+      <View>
+        <Text>
+          Handling of JS exception
+        </Text>
+      </View>
+    );
+  }
+});
+
+TestJSException.displayName = 'TestJSException';
+AppRegistry.registerComponent('TestJSException', () => TestJSException);
+
+module.exports = TestJSException;

--- a/ReactQt/runtime/src/qml/ReactRedboxItem.qml
+++ b/ReactQt/runtime/src/qml/ReactRedboxItem.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.4
-import QtQuick.Controls 1.4
+import QtQuick.Controls 2.2
 
 Rectangle {
     id: redboxRoot

--- a/ReactQt/runtime/src/reactbridge.cpp
+++ b/ReactQt/runtime/src/reactbridge.cpp
@@ -133,18 +133,24 @@ void ReactBridge::reload() {
     Q_D(ReactBridge);
 
     setReady(false);
+    setJsAppStarted(false);
 
     d->executor->deleteLater();
     setupExecutor();
 
     // d->uiManager->reset();
     for (auto& md : d->modules) {
-        delete md;
+        md->deleteLater();
     }
     d->modules.clear();
     initModules();
     injectModules();
     loadSource();
+}
+
+void ReactBridge::loadBundle(const QUrl& bundleUrl) {
+    setBundleUrl(bundleUrl);
+    reload();
 }
 
 void ReactBridge::enqueueJSCall(const QString& module, const QString& method, const QVariantList& args) {

--- a/ReactQt/runtime/src/reactbridge.h
+++ b/ReactQt/runtime/src/reactbridge.h
@@ -53,6 +53,7 @@ public:
 
     void init();
     void reload();
+    void loadBundle(const QUrl& bundleUrl);
 
     void invokePromiseCallback(double callbackCode, const QVariantList& args);
     void enqueueJSCall(const QString& module, const QString& method, const QVariantList& args);

--- a/ReactQt/runtime/src/reactmoduledata.h
+++ b/ReactQt/runtime/src/reactmoduledata.h
@@ -21,8 +21,9 @@ class ReactModuleMethod;
 class ReactViewManager;
 
 class ReactModuleDataPrivate;
-class ReactModuleData {
+class ReactModuleData : public QObject {
     Q_DECLARE_PRIVATE(ReactModuleData)
+    Q_OBJECT
 
 public:
     ReactModuleData(QObject* moduleImpl, int id);

--- a/ReactQt/runtime/src/reactredboxitem.cpp
+++ b/ReactQt/runtime/src/reactredboxitem.cpp
@@ -28,6 +28,8 @@ enum Roles {
 static QHash<int, QByteArray> roleData{
     {LineNumber, "lineNumber"}, {Column, "column"}, {File, "file"}, {MethodName, "methodName"},
 };
+
+const char REDBOX_MESSAGE_PROPERTY[] = "message";
 }
 
 class ReactRedboxItemPrivate : public QAbstractListModel {
@@ -116,7 +118,7 @@ ReactRedboxItem::~ReactRedboxItem() {}
 
 void ReactRedboxItem::showErrorMessage(const QString& message, const QList<QVariantMap>& stack) {
     Q_D(ReactRedboxItem);
-    d->redbox->setProperty("message", message);
+    d->redbox->setProperty(REDBOX_MESSAGE_PROPERTY, message);
     d->setStack(stack);
 
     QQuickItem* rootView = d->bridge->visualParent();
@@ -130,8 +132,12 @@ void ReactRedboxItem::showErrorMessage(const QString& message, const QList<QVari
 
 void ReactRedboxItem::updateErrorMessage(const QString& message, const QList<QVariantMap>& stack) {
     Q_D(ReactRedboxItem);
-    d->redbox->setProperty("message", message);
+    d->redbox->setProperty(REDBOX_MESSAGE_PROPERTY, message);
     d->setStack(stack);
+}
+
+QString ReactRedboxItem::errorMessage() const {
+    return d_func()->redbox->property(REDBOX_MESSAGE_PROPERTY).toString();
 }
 
 #include "reactredboxitem.moc"

--- a/ReactQt/runtime/src/reactredboxitem.h
+++ b/ReactQt/runtime/src/reactredboxitem.h
@@ -26,6 +26,8 @@ public:
     void showErrorMessage(const QString& message, const QList<QVariantMap>& stack = QList<QVariantMap>());
     void updateErrorMessage(const QString& message, const QList<QVariantMap>& stack = QList<QVariantMap>());
 
+    QString errorMessage() const;
+
 private:
     QScopedPointer<ReactRedboxItemPrivate> d_ptr;
 };

--- a/ReactQt/runtime/src/reacttestmodule.cpp
+++ b/ReactQt/runtime/src/reacttestmodule.cpp
@@ -36,7 +36,9 @@ QList<ReactModuleMethod*> ReactTestModule::methodsToExport() {
     return QList<ReactModuleMethod*>{};
 }
 
-QVariantMap ReactTestModule::constantsToExport() {}
+QVariantMap ReactTestModule::constantsToExport() {
+    return QVariantMap{};
+}
 
 void ReactTestModule::markTestCompleted() {
     emit testCompleted();

--- a/ReactQt/runtime/src/reactuimanager.cpp
+++ b/ReactQt/runtime/src/reactuimanager.cpp
@@ -437,9 +437,9 @@ void ReactUIManager::setBridge(ReactBridge* bridge) {
         }
     }
 
-    connect(m_bridge->visualParent(), SIGNAL(widthChanged()), SLOT(rootViewWidthChanged()));
-    connect(m_bridge->visualParent(), SIGNAL(heightChanged()), SLOT(rootViewHeightChanged()));
-    connect(m_bridge->visualParent(), SIGNAL(scaleChanged()), SLOT(rootViewScaleChanged()));
+    connect(m_bridge->visualParent(), SIGNAL(widthChanged()), SLOT(onRootViewWidthChanged()));
+    connect(m_bridge->visualParent(), SIGNAL(heightChanged()), SLOT(onRootViewHeightChanged()));
+    connect(m_bridge->visualParent(), SIGNAL(scaleChanged()), SLOT(onRootViewScaleChanged()));
 }
 
 QString ReactUIManager::moduleName() {
@@ -521,21 +521,21 @@ QQuickItem* ReactUIManager::viewForTag(int reactTag) {
     return m_views.value(reactTag);
 }
 
-void ReactUIManager::rootViewWidthChanged() {
+void ReactUIManager::onRootViewWidthChanged() {
     QQuickItem* root = m_bridge->visualParent();
     if (ReactAttachedProperties::get(root)->tag() == -1)
         return;
     root->polish();
 }
 
-void ReactUIManager::rootViewHeightChanged() {
+void ReactUIManager::onRootViewHeightChanged() {
     QQuickItem* root = m_bridge->visualParent();
     if (ReactAttachedProperties::get(root)->tag() == -1)
         return;
     root->polish();
 }
 
-void ReactUIManager::rootViewScaleChanged() {
+void ReactUIManager::onRootViewScaleChanged() {
     QQuickItem* root = m_bridge->visualParent();
     if (ReactAttachedProperties::get(root)->tag() == -1)
         return;

--- a/ReactQt/runtime/src/reactuimanager.h
+++ b/ReactQt/runtime/src/reactuimanager.h
@@ -86,9 +86,9 @@ public:
     QQuickItem* viewForTag(int reactTag);
 
 public Q_SLOTS:
-    void rootViewWidthChanged();
-    void rootViewHeightChanged();
-    void rootViewScaleChanged();
+    void onRootViewWidthChanged();
+    void onRootViewHeightChanged();
+    void onRootViewScaleChanged();
 
 private:
     static int m_nextRootTag;

--- a/ReactQt/runtime/src/reactview.cpp
+++ b/ReactQt/runtime/src/reactview.cpp
@@ -18,6 +18,7 @@
 #include "reactbridge.h"
 #include "reactevents.h"
 #include "reactflexlayout.h"
+#include "reactredboxitem.h"
 #include "reactuimanager.h"
 #include "reactview.h"
 
@@ -103,7 +104,7 @@ public:
     }
 
 private Q_SLOTS:
-    void liveReloadChanged() {
+    void onLiveReloadChanged() {
         if (!liveReload)
             return;
         if (bridge != nullptr && bridge->ready())
@@ -120,7 +121,7 @@ ReactView::ReactView(QQuickItem* parent) : ReactItem(parent), d_ptr(new ReactVie
     d->bridge = new ReactBridge(this);
     connect(d->bridge, SIGNAL(readyChanged()), SLOT(bridgeReady()));
 
-    connect(this, SIGNAL(liveReloadChanged()), d, SLOT(liveReloadChanged()));
+    connect(this, SIGNAL(liveReloadChanged()), d, SLOT(onLiveReloadChanged()));
 }
 
 ReactView::~ReactView() {}
@@ -198,6 +199,17 @@ void ReactView::setExecutor(const QString& executor) {
 
 ReactBridge* ReactView::bridge() const {
     return d_func()->bridge;
+}
+
+void ReactView::loadBundle(const QString& moduleName, const QUrl& codeLocation) {
+    Q_ASSERT(!moduleName.isEmpty() && !codeLocation.isEmpty());
+
+    setModuleName(moduleName);
+    setCodeLocation(codeLocation);
+
+    if (bridge()) {
+        bridge()->loadBundle(codeLocation);
+    }
 }
 
 void ReactView::bridgeReady() {

--- a/ReactQt/runtime/src/reactview.h
+++ b/ReactQt/runtime/src/reactview.h
@@ -59,6 +59,8 @@ public:
 
     ReactBridge* bridge() const;
 
+    void loadBundle(const QString& moduleName, const QUrl& codeLocation);
+
 Q_SIGNALS:
     void liveReloadChanged();
     void moduleNameChanged();

--- a/ReactQt/tests/reacttestcase.h
+++ b/ReactQt/tests/reacttestcase.h
@@ -10,23 +10,36 @@
 class ReactView;
 class ReactBridge;
 
+#define INIT_TEST_CASE_DEFAULT(BaseClass)                                                                              \
+    virtual void initTestCase() override {                                                                             \
+        BaseClass::initTestCase();                                                                                     \
+    }
+
+#define CLEANUP_TEST_CASE_DEFAULT(BaseClass)                                                                           \
+    virtual void cleanupTestCase() override {                                                                          \
+        BaseClass::cleanupTestCase();                                                                                  \
+    }
+
 class ReactTestCase : public QObject {
     Q_OBJECT
 public:
     explicit ReactTestCase(QObject* parent = nullptr);
     virtual ~ReactTestCase() {}
 
+    virtual void initTestCase();
+    virtual void cleanupTestCase();
+
 signals:
 
 protected:
-    virtual void initTestCase();
-    virtual void cleanupTestCase();
     void loadQML(const QUrl& qmlUrl);
+    void loadJSBundle(const QString& moduleName, const QString& bundlePath);
     ReactView* rootView() const;
     ReactBridge* bridge();
     void showView();
     void waitAndVerifyBridgeReady();
     void waitAndVerifyJsAppStarted();
+    void waitAndVerifyJSException(const QString& exceptionMessage);
     void waitAndVerifyCondition(std::function<bool()> condition, const QString& timeoutMessage);
 
 private:


### PR DESCRIPTION
- Possibility to reload ReactView with specified JS bundle URL ( One unit test class can load different JS bundles in different test methods. It's not required to create separate QML files for each different JS bundle used inside 1 test class  )
- Unit test to validate receiving of exception thrown by JS code
- Some slots titles adjusted to format `onSomethingChanged`. Prefix `on` is used to distinguish slots from signals.
- Macroses to define base implementation for unit tests `init` and `clean` functionality 