### PR TITLE
Added missing import.

### DIFF
--- a/ReactQt/runtime/src/reactpropertyhandler.h
+++ b/ReactQt/runtime/src/reactpropertyhandler.h
@@ -14,6 +14,8 @@
 #ifndef REACTPROPERTYHANDLER_H
 #define REACTPROPERTYHANDLER_H
 
+#include <functional>
+
 #include <QMap>
 #include <QMetaProperty>
 #include <QObject>


### PR DESCRIPTION
Using docker ubuntu:zesty to build this (cmake 3.7.2, g++ 6.3.0) I was experiencing a build error:

```
In file included from /react-native-linux/ReactQt/runtime/src/reactpropertyhandler.cpp:16:0:
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.h:25:34: error: 'function' in namespace 'std' does not name a template type
 using SetPropertyCallback = std::function<void(QObject* object, QMetaProperty property, const QVariant& value)>;
                                  ^~~~~~~~
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.h:31:43: error: 'SetPropertyCallback' has not been declared
     ReactPropertyHandler(QObject* object, SetPropertyCallback callback = SetPropertyCallback());
                                           ^~~~~~~~~~~~~~~~~~~
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.h:49:5: error: 'SetPropertyCallback' does not name a type
     SetPropertyCallback m_setPropertyCallback;
     ^~~~~~~~~~~~~~~~~~~
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.h:31:94: error: 'SetPropertyCallback' was not declared in this scope
     ReactPropertyHandler(QObject* object, SetPropertyCallback callback = SetPropertyCallback());
                                                                                              ^
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.cpp:19:61: error: 'SetPropertyCallback' has not been declared
 ReactPropertyHandler::ReactPropertyHandler(QObject* object, SetPropertyCallback callback)
                                                             ^~~~~~~~~~~~~~~~~~~
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.cpp: In constructor 'ReactPropertyHandler::ReactPropertyHandler(QObject*, int)':
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.cpp:20:42: error: class 'ReactPropertyHandler' does not have any field named 'm_setPropertyCallback'
     : QObject(object), m_object(object), m_setPropertyCallback(callback) {}
                                          ^~~~~~~~~~~~~~~~~~~~~
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.cpp: In member function 'void ReactPropertyHandler::setValueToObjectProperty(QObject*, QMetaProperty, const QVariant&)':
/react-native-linux/ReactQt/runtime/src/reactpropertyhandler.cpp:106:9: error: 'm_setPropertyCallback' was not declared in this scope
     if (m_setPropertyCallback) {
         ^~~~~~~~~~~~~~~~~~~~~
```

The failing command was:
```
/usr/bin/c++ -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_QML_LIB -DQT_QUICK_LIB -Dreact_native_EXPORTS -I/react-native-linux/ReactQt/runtime/src -I/react-native-linux/./React/Layout -isystem /usr/include/x86_64-linux-gnu/qt5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore -isystem /usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -isystem /usr/include/x86_64-linux-gnu/qt5/QtQml -isystem /usr/include/x86_64-linux-gnu/qt5/QtNetwork -isystem /usr/include/x86_64-linux-gnu/qt5/QtQuick -isystem /usr/include/x86_64-linux-gnu/qt5/QtGui -std=c++11 -fPIC -fPIC -std=gnu++11 -o CMakeFiles/react-native.dir/reactpropertyhandler.cpp.o -c /react-native-linux/ReactQt/runtime/src/reactpropertyhandler.cpp
```

The remedy was to add an include for ```<functional>```