### PR TITLE
refs #87 - Basic Slider component props support; Slider props unit test

### DIFF
--- a/RNTester/js/RNTesterList.ubuntu.js
+++ b/RNTester/js/RNTesterList.ubuntu.js
@@ -37,6 +37,10 @@ const ComponentExamples: Array<RNTesterExample> = [
     key: 'LayoutExample',
     module: require('./LayoutExample'),
   },
+  {
+    key: 'SliderExample',
+    module: require('./SliderExample'),
+  },
 ];
 
 const APIExamples: Array<RNTesterExample> = [

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -51,6 +51,7 @@ set(
   reactredboxitem.cpp
   reactexceptionsmanager.cpp
   reactscrollviewmanager.cpp
+  reactslidermanager.cpp
   reactnavigatormanager.cpp
   reactactivityindicatormanager.cpp
   reactbuttonmanager.cpp
@@ -72,6 +73,7 @@ set(
   qml/ReactRawText.qml
   qml/ReactActivityIndicator.qml
   qml/ReactButton.qml
+  qml/ReactSlider.qml
 )
 
 if(DEFINED REACT_BUILD_STATIC_LIB)

--- a/ReactQt/runtime/src/qml/ReactSlider.qml
+++ b/ReactQt/runtime/src/qml/ReactSlider.qml
@@ -1,0 +1,45 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtGraphicalEffects 1.0
+import React 0.1 as React
+
+Slider {
+    id: sliderRoot
+
+    property var sliderManager: null
+
+    property double p_value
+    property double p_step
+    property double p_minimumValue
+    property double p_maximumValue
+    property string p_minimumTrackTintColor
+    property string p_maximumTrackTintColor
+    property bool p_disabled: false
+    property var p_trackImage
+    property var p_minimumTrackImage
+    property var p_maximumTrackImage
+    property var p_thumbImage
+    property string p_thumbTintColor
+    property string p_testID
+    property var flexbox: React.Flexbox {control: sliderRoot}
+
+    objectName: p_testID
+
+    implicitHeight: 40
+    implicitWidth: 100
+
+    value: p_value
+    stepSize: p_step
+    from: p_minimumValue
+    to: p_maximumValue
+    enabled: !p_disabled
+
+    onValueChanged: {
+        sliderManager.sendSliderValueChangedToJs(sliderRoot)
+    }
+
+    onPressedChanged: {
+        if (!pressed)
+            sliderManager.sendSlidingCompleteToJs(sliderRoot)
+    }
+}

--- a/ReactQt/runtime/src/react_resources.qrc
+++ b/ReactQt/runtime/src/react_resources.qrc
@@ -10,5 +10,6 @@
         <file>qml/ReactActivityIndicator.qml</file>
         <file>images/spinner_medium.png</file>
         <file>qml/ReactButton.qml</file>
+        <file>qml/ReactSlider.qml</file>
     </qresource>
 </RCC>

--- a/ReactQt/runtime/src/reactbridge.cpp
+++ b/ReactQt/runtime/src/reactbridge.cpp
@@ -45,6 +45,7 @@
 #include "reactrawtextmanager.h"
 #include "reactredboxitem.h"
 #include "reactscrollviewmanager.h"
+#include "reactslidermanager.h"
 #include "reacttestmodule.h"
 #include "reacttextmanager.h"
 #include "reacttiming.h"
@@ -88,6 +89,7 @@ public:
             new ReactNavigatorManager,
             new ReactActivityIndicatorManager,
             new ReactButtonManager,
+            new ReactSliderManager,
         };
     }
 };

--- a/ReactQt/runtime/src/reactslidermanager.cpp
+++ b/ReactQt/runtime/src/reactslidermanager.cpp
@@ -1,0 +1,87 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <QDebug>
+#include <QQmlComponent>
+#include <QQmlProperty>
+#include <QQuickItem>
+#include <QString>
+#include <QVariant>
+
+#include "layout/flexbox.h"
+#include "reactattachedproperties.h"
+#include "reactbridge.h"
+#include "reactevents.h"
+#include "reactpropertyhandler.h"
+#include "reactslidermanager.h"
+
+namespace {
+const QString EVENT_ON_VALUE_CHANGED = "onValueChange";
+const QString EVENT_ON_SLIDING_COMPLETE = "onSlidingComplete";
+
+const char SLIDER_VALUE_PROPERTY_NAME[] = "value";
+}
+
+class ReactSliderManagerPrivate {};
+
+ReactSliderManager::ReactSliderManager(QObject* parent)
+    : ReactViewManager(parent), d_ptr(new ReactSliderManagerPrivate) {}
+
+ReactSliderManager::~ReactSliderManager() {}
+
+ReactViewManager* ReactSliderManager::viewManager() {
+    return this;
+}
+
+QString ReactSliderManager::moduleName() {
+    return "RCTSliderManager";
+}
+
+QStringList ReactSliderManager::customDirectEventTypes() {
+    return QStringList{
+        normalizeInputEventName(EVENT_ON_VALUE_CHANGED), normalizeInputEventName(EVENT_ON_SLIDING_COMPLETE),
+    };
+}
+
+void ReactSliderManager::sendSliderValueChangedToJs(QQuickItem* slider) {
+    if (!slider)
+        return;
+    QVariantList args = sliderValueEventArg(slider, EVENT_ON_VALUE_CHANGED);
+    bridge()->enqueueJSCall("RCTEventEmitter", "receiveEvent", args);
+}
+
+void ReactSliderManager::sendSlidingCompleteToJs(QQuickItem* slider) {
+    if (!slider)
+        return;
+    QVariantList args = sliderValueEventArg(slider, EVENT_ON_SLIDING_COMPLETE);
+    bridge()->enqueueJSCall("RCTEventEmitter", "receiveEvent", args);
+}
+
+QString ReactSliderManager::qmlComponentFile() const {
+    return ":/qml/ReactSlider.qml";
+}
+
+void ReactSliderManager::configureView(QQuickItem* view) const {
+    ReactViewManager::configureView(view);
+    view->setProperty("sliderManager", QVariant::fromValue((QObject*)this));
+}
+
+QVariantList ReactSliderManager::sliderValueEventArg(QQuickItem* slider, const QString& eventName) const {
+    if (!slider)
+        return QVariantList();
+
+    double sliderValue = slider->property(SLIDER_VALUE_PROPERTY_NAME).toDouble();
+    int reactTag = ReactAttachedProperties::get(slider)->tag();
+    return QVariantList{
+        reactTag, normalizeInputEventName(eventName), QVariantMap{{"target", reactTag}, {"value", sliderValue}}};
+}
+
+#include "reactslidermanager.moc"

--- a/ReactQt/runtime/src/reactslidermanager.h
+++ b/ReactQt/runtime/src/reactslidermanager.h
@@ -1,0 +1,45 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef REACTSLIDERMANAGER_H
+#define REACTSLIDERMANAGER_H
+
+#include "reactviewmanager.h"
+
+class ReactSliderManagerPrivate;
+class ReactSliderManager : public ReactViewManager {
+    Q_OBJECT
+    Q_INTERFACES(ReactModuleInterface)
+    Q_DECLARE_PRIVATE(ReactSliderManager)
+
+public:
+    ReactSliderManager(QObject* parent = 0);
+    virtual ~ReactSliderManager();
+
+    virtual ReactViewManager* viewManager() override;
+    virtual QString moduleName() override;
+    virtual QStringList customDirectEventTypes() override;
+
+public slots:
+    void sendSliderValueChangedToJs(QQuickItem* slider);
+    void sendSlidingCompleteToJs(QQuickItem* slider);
+
+private:
+    virtual QString qmlComponentFile() const override;
+    virtual void configureView(QQuickItem* view) const override;
+
+    QVariantList sliderValueEventArg(QQuickItem* slider, const QString& eventName) const;
+
+private:
+    QScopedPointer<ReactSliderManagerPrivate> d_ptr;
+};
+
+#endif // REACTSLIDERMANAGER_H

--- a/ReactQt/tests/CMakeLists.txt
+++ b/ReactQt/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(REACT_TESTCASE_JS
   JS/TestImageProps.js
   JS/TestActivityIndicatorProps.js
   JS/TestButtonProps.js
+  JS/TestSliderProps.js
 )
 
 set(
@@ -35,17 +36,20 @@ set(
 
 add_executable(test-integration test-integration.cpp resources.qrc ${REACT_TESTCASE_SRC})
 add_executable(test-image-props test-image-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
+add_executable(test-slider-props test-slider-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 add_executable(test-activityindicator-props test-activityindicator-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 add_executable(test-button-props test-button-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 
 
 add_test(test-integration test-integration)
 add_test(test-image-props test-image-props)
+add_test(test-slider-props test-slider-props)
 add_test(test-activityindicator-props test-activityindicator-props)
 add_test(test-button-props test-button-props)
 
 target_link_libraries(test-integration ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-image-props ${REACT_TESTCASE_LIBRARIES})
+target_link_libraries(test-slider-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-activityindicator-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-button-props ${REACT_TESTCASE_LIBRARIES})
 

--- a/ReactQt/tests/JS/TestSliderProps.js
+++ b/ReactQt/tests/JS/TestSliderProps.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import {
+  AppRegistry,
+  StyleSheet,
+  Text,
+  View,
+  Slider
+} from 'react-native';
+
+export default class SliderReactNative extends Component {
+  render() {
+    return (
+      <Slider
+        value={0.5}
+        step={0.1}
+        minimumValue={0}
+        maximumValue={1.0}
+        minimumTrackTintColor={'green'}
+        maximumTrackTintColor={'green'}
+        disabled={false}
+        onValueChange={() => console.log('Slider.onValueChange()')}
+        onSlidingComplete={() => console.log('Slider.onSlidingComplete()')}
+        trackImage={false}
+        minimumTrackImage={false}
+        maximumTrackImage={false}
+        thumbImage={false}
+        thumbTintColor={'green'}
+        testID={'testSlider'}
+        />
+    );
+  }
+}
+
+AppRegistry.registerComponent('TestSliderProps', () => SliderReactNative);

--- a/ReactQt/tests/TestSliderProps.qml
+++ b/ReactQt/tests/TestSliderProps.qml
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+import QtQuick 2.4
+import React 0.1 as React
+
+Rectangle {
+    id: root
+    width: 640; height: 480;
+
+    React.RootView {
+        objectName: "rootView"
+        anchors.fill: parent
+
+        moduleName: "TestSliderProps"
+        codeLocation: "http://localhost:8081/ReactQt/tests/JS/TestSliderProps.bundle?platform=ubuntu&dev=true"
+    }
+}

--- a/ReactQt/tests/reactpropertytestcase.cpp
+++ b/ReactQt/tests/reactpropertytestcase.cpp
@@ -1,6 +1,7 @@
 #include "reacttestcase.h"
 
 #include "reactpropertytestcase.h"
+#include "rootview.h"
 #include <QQuickItem>
 #include <QTest>
 
@@ -15,4 +16,24 @@ void ReactPropertyTestCase::testProperties() {
 
 QVariant ReactPropertyTestCase::valueOfProperty(const QString& propertyName) {
     return control()->property(propertyName.toStdString().c_str());
+}
+
+QQuickItem* ReactPropertyTestCase::singleControl() const {
+    // Even when in JS we have only one <Image> component returned in render(),
+    // it is wrapped in <View> component implicitly, so we have hierarchy in QML:
+    // ReactView
+    //  |-<View>
+    //    |-<Image>
+
+    QList<QQuickItem*> reactViewChilds = rootView()->childItems();
+    Q_ASSERT(reactViewChilds.count() == 1);
+
+    QQuickItem* view = reactViewChilds[0];
+    QList<QQuickItem*> viewChilds = view->childItems();
+    Q_ASSERT(viewChilds.count() == 1);
+
+    QQuickItem* control = viewChilds[0];
+    Q_ASSERT(control);
+
+    return control;
 }

--- a/ReactQt/tests/reactpropertytestcase.h
+++ b/ReactQt/tests/reactpropertytestcase.h
@@ -17,6 +17,7 @@ protected:
     virtual QVariantMap propValues() const = 0;
     virtual QQuickItem* control() const = 0;
     QVariant valueOfProperty(const QString& propertyName);
+    QQuickItem* singleControl() const;
 };
 
 #endif // REACTPROPERTYTTESTCASE_H

--- a/ReactQt/tests/resources.qrc
+++ b/ReactQt/tests/resources.qrc
@@ -4,5 +4,6 @@
         <file>TestImageProps.qml</file>
         <file>TestActivityIndicatorProps.qml</file>
         <file>TestButtonProps.qml</file>
+        <file>TestSliderProps.qml</file>
     </qresource>
 </RCC>

--- a/ReactQt/tests/test-image-props.cpp
+++ b/ReactQt/tests/test-image-props.cpp
@@ -9,7 +9,7 @@
  */
 
 #include "reactpropertytestcase.h"
-#include "rootview.h"
+
 #include <QDebug>
 #include <QTest>
 #include <QtQuick/QQuickView>
@@ -30,23 +30,7 @@ protected:
 };
 
 QQuickItem* TestImageProps::control() const {
-    // Even when in JS we have only one <Image> component returned in render(),
-    // it is wrapped in <View> component implicitly, so we have hierarchy in QML:
-    // ReactView
-    //  |-<View>
-    //    |-<Image>
-
-    QList<QQuickItem*> reactViewChilds = rootView()->childItems();
-    Q_ASSERT(reactViewChilds.count() == 1);
-
-    QQuickItem* view = reactViewChilds[0];
-    QList<QQuickItem*> viewChilds = view->childItems();
-    Q_ASSERT(viewChilds.count() == 1);
-
-    QQuickItem* image = viewChilds[0];
-    Q_ASSERT(image);
-
-    return image;
+    return singleControl();
 }
 
 void TestImageProps::initTestCase() {

--- a/ReactQt/tests/test-slider-props.cpp
+++ b/ReactQt/tests/test-slider-props.cpp
@@ -14,11 +14,8 @@
 #include <QTest>
 #include <QtQuick/QQuickView>
 
-class TestButtonProps : public ReactPropertyTestCase {
+class TestSliderProps : public ReactPropertyTestCase {
     Q_OBJECT
-
-private:
-    QQuickItem* qmlImage();
 
 private slots:
 
@@ -29,24 +26,31 @@ protected:
     virtual QVariantMap propValues() const override;
 };
 
-QQuickItem* TestButtonProps::control() const {
+QQuickItem* TestSliderProps::control() const {
     return singleControl();
 }
 
-void TestButtonProps::initTestCase() {
+void TestSliderProps::initTestCase() {
     ReactPropertyTestCase::initTestCase();
-    loadQML(QUrl("qrc:/TestButtonProps.qml"));
+    loadQML(QUrl("qrc:/TestSliderProps.qml"));
     waitAndVerifyJsAppStarted();
 }
 
-QVariantMap TestButtonProps::propValues() const {
-    return {{"p_accessibilityLabel", "Accessibility label"},
-            {"p_title", "Click me"},
-            {"p_color", "red"},
+QVariantMap TestSliderProps::propValues() const {
+    return {{"p_value", 0.5},
+            {"p_step", 0.1},
+            {"p_minimumValue", 0},
+            {"p_maximumValue", 1.0},
+            {"p_minimumTrackTintColor", "green"},
+            {"p_maximumTrackTintColor", "green"},
             {"p_disabled", false},
-            {"p_onPress", true},
-            {"p_testID", "button"}};
+            {"p_trackImage", false},
+            {"p_minimumTrackImage", false},
+            {"p_maximumTrackImage", false},
+            {"p_thumbImage", false},
+            {"p_thumbTintColor", "green"},
+            {"p_testID", "testSlider"}};
 }
 
-QTEST_MAIN(TestButtonProps)
-#include "test-button-props.moc"
+QTEST_MAIN(TestSliderProps)
+#include "test-slider-props.moc"


### PR DESCRIPTION
- Basic support of Slider component (basic props)
- Slider props unit test
- Added SliderExample.js to the list of examples supported by RnTester
