### PR TITLE
Fixed bug with <Button> becoming invisible

### DIFF
--- a/ReactQt/runtime/src/layout/flexbox.cpp
+++ b/ReactQt/runtime/src/layout/flexbox.cpp
@@ -627,6 +627,10 @@ void Flexbox::setDirection(const QString& value) {
     }
 }
 
+bool Flexbox::isDirty() {
+    return YGNodeIsDirty(d_ptr->m_node);
+}
+
 void printYGNode(YGNodeRef node, const QString& nodeName) {
     qDebug() << nodeName << ": width: " << YGNodeLayoutGetWidth(node) << " height: " << YGNodeLayoutGetHeight(node)
              << " x: " << YGNodeLayoutGetLeft(node) << " y: " << YGNodeLayoutGetTop(node);

--- a/ReactQt/runtime/src/layout/flexbox.h
+++ b/ReactQt/runtime/src/layout/flexbox.h
@@ -77,6 +77,7 @@ class Flexbox : public QObject {
     Q_PROPERTY(QString p_overflow READ overflow WRITE setOverflow NOTIFY overflowChanged)
     Q_PROPERTY(QString p_position READ position WRITE setPosition NOTIFY positionChanged)
     Q_PROPERTY(QString p_direction READ direction WRITE setDirection NOTIFY directionChanged)
+    Q_PROPERTY(QString isDirty READ isDirty NOTIFY isDirtyChanged)
 
 signals:
     void widthChanged();
@@ -124,6 +125,7 @@ signals:
     void overflowChanged();
     void positionChanged();
     void directionChanged();
+    void isDirtyChanged();
 
 public:
     Flexbox(QObject* parent = 0);
@@ -222,6 +224,7 @@ public:
     void setPosition(const QString& value);
     QString direction();
     void setDirection(const QString& value);
+    bool isDirty();
 
 private:
     QScopedPointer<FlexboxPrivate> d_ptr;

--- a/ReactQt/runtime/src/qml/ReactButton.qml
+++ b/ReactQt/runtime/src/qml/ReactButton.qml
@@ -13,16 +13,24 @@ Button {
     property bool p_onPress: false
     property string p_testID
     property var buttonManager: null
-    property var flexbox: React.Flexbox {control: buttonRoot}
-    property var textFlexbox: React.Flexbox {control: contentItem}
+    property var flexbox: React.Flexbox {
+        control: buttonRoot
+        p_minWidth: buttonRoot.contentItem.contentWidth + 2*priv.textMargin
+        p_minHeight: buttonRoot.contentItem.contentHeight + 2*priv.textMargin
+    }
+
+    QtObject {
+        id: priv
+        property int textMargin: 5
+    }
 
     text: p_title
     objectName: p_testID
     enabled: !p_disabled
 
-
-    implicitHeight: 40
-    implicitWidth: 100
+    Component.onCompleted: {
+        buttonRoot.contentItem.elide = Text.ElideNone
+    }
 
     background: Rectangle {
         color: buttonRoot.down ? Qt.darker(buttonRoot.p_color, 1.2) : buttonRoot.p_color

--- a/ReactQt/runtime/src/reactbuttonmanager.cpp
+++ b/ReactQt/runtime/src/reactbuttonmanager.cpp
@@ -70,24 +70,6 @@ void ReactButtonManager::sendPressedNotificationToJs(QQuickItem* button) {
         "RCTEventEmitter", "receiveEvent", QVariantList{reactTag, normalizeInputEventName(EVENT_ONPRESSED), {}});
 }
 
-void ReactButtonManager::setCustomFlexboxMeasureFunctionToButtonText(QQuickItem* button) const {
-    const Q_D(ReactButtonManager);
-
-    QQuickItem* textControl = d->buttonTextControl(button);
-    Flexbox* textFlexbox = Flexbox::findFlexbox(textControl);
-    Flexbox* buttonFlexbox = Flexbox::findFlexbox(button);
-
-    buttonFlexbox->addChild(0, textFlexbox);
-
-    textFlexbox->setMeasureFunction([=](YGNodeRef, float width, YGMeasureMode, float height, YGMeasureMode) {
-        Q_UNUSED(width);
-        Q_UNUSED(height);
-        float w = textControl->width();
-        float ch = textControl->property("contentHeight").toDouble();
-        return YGSize{w, ch};
-    });
-}
-
 QString ReactButtonManager::qmlComponentFile() const {
     return ":/qml/ReactButton.qml";
 }
@@ -95,7 +77,6 @@ QString ReactButtonManager::qmlComponentFile() const {
 void ReactButtonManager::configureView(QQuickItem* button) const {
     ReactViewManager::configureView(button);
     button->setProperty("buttonManager", QVariant::fromValue((QObject*)this));
-    setCustomFlexboxMeasureFunctionToButtonText(button);
 }
 
 #include "reactbuttonmanager.moc"

--- a/ReactQt/runtime/src/reactbuttonmanager.h
+++ b/ReactQt/runtime/src/reactbuttonmanager.h
@@ -30,7 +30,6 @@ public:
 
 public slots:
     void sendPressedNotificationToJs(QQuickItem* button);
-    void setCustomFlexboxMeasureFunctionToButtonText(QQuickItem* button) const;
 
 private:
     virtual QString qmlComponentFile() const override;

--- a/ReactQt/tests/CMakeLists.txt
+++ b/ReactQt/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(REACT_TESTCASE_JS
   JS/TestActivityIndicatorProps.js
   JS/TestButtonProps.js
   JS/TestSliderProps.js
+  JS/TestButtonSize.js
 )
 
 set(
@@ -39,6 +40,7 @@ add_executable(test-image-props test-image-props.cpp resources.qrc ${REACT_TESTC
 add_executable(test-slider-props test-slider-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 add_executable(test-activityindicator-props test-activityindicator-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 add_executable(test-button-props test-button-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
+add_executable(test-button-size test-button-size.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 
 
 add_test(test-integration test-integration)
@@ -46,12 +48,14 @@ add_test(test-image-props test-image-props)
 add_test(test-slider-props test-slider-props)
 add_test(test-activityindicator-props test-activityindicator-props)
 add_test(test-button-props test-button-props)
+add_test(test-button-size test-button-size)
 
 target_link_libraries(test-integration ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-image-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-slider-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-activityindicator-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-button-props ${REACT_TESTCASE_LIBRARIES})
+target_link_libraries(test-button-size ${REACT_TESTCASE_LIBRARIES})
 
 set_target_properties(
   test-integration

--- a/ReactQt/tests/JS/TestButtonSize.js
+++ b/ReactQt/tests/JS/TestButtonSize.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import {
+  AppRegistry,
+  StyleSheet,
+  View,
+  Button
+} from 'react-native';
+
+export default class TestButtonSize extends Component {
+
+   render() {
+      return (
+         <View nativeID={"TopView"} style = {styles.container}>
+               <View nativeID={"Content"} style = {styles.modal}>
+                 <Button testID={"TestButton"}
+                    title='Long enough button'>
+                 </Button>
+               </View>
+         </View>
+      )
+   }
+}
+
+const styles = StyleSheet.create ({
+   container: {
+      alignItems: 'center',
+      backgroundColor: '#00ff00',
+   },
+   modal: {
+      flex: 1,
+      alignItems: 'center',
+      backgroundColor: '#ff0000',
+   }
+})
+
+AppRegistry.registerComponent('TestButtonSize', () => TestButtonSize)

--- a/ReactQt/tests/TestButtonSize.qml
+++ b/ReactQt/tests/TestButtonSize.qml
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+import QtQuick 2.4
+import React 0.1 as React
+
+Rectangle {
+    id: root
+    width: 640; height: 480;
+
+    React.RootView {
+        objectName: "rootView"
+        anchors.fill: parent
+
+        moduleName: "TestButtonSize"
+        codeLocation: "http://localhost:8081/ReactQt/tests/JS/TestButtonSize.bundle?platform=ubuntu&dev=true"
+    }
+}

--- a/ReactQt/tests/reactpropertytestcase.cpp
+++ b/ReactQt/tests/reactpropertytestcase.cpp
@@ -15,25 +15,5 @@ void ReactPropertyTestCase::testProperties() {
 }
 
 QVariant ReactPropertyTestCase::valueOfProperty(const QString& propertyName) {
-    return control()->property(propertyName.toStdString().c_str());
-}
-
-QQuickItem* ReactPropertyTestCase::singleControl() const {
-    // Even when in JS we have only one <Image> component returned in render(),
-    // it is wrapped in <View> component implicitly, so we have hierarchy in QML:
-    // ReactView
-    //  |-<View>
-    //    |-<Image>
-
-    QList<QQuickItem*> reactViewChilds = rootView()->childItems();
-    Q_ASSERT(reactViewChilds.count() == 1);
-
-    QQuickItem* view = reactViewChilds[0];
-    QList<QQuickItem*> viewChilds = view->childItems();
-    Q_ASSERT(viewChilds.count() == 1);
-
-    QQuickItem* control = viewChilds[0];
-    Q_ASSERT(control);
-
-    return control;
+    return valueOfControlProperty(control(), propertyName);
 }

--- a/ReactQt/tests/reactpropertytestcase.h
+++ b/ReactQt/tests/reactpropertytestcase.h
@@ -17,7 +17,6 @@ protected:
     virtual QVariantMap propValues() const = 0;
     virtual QQuickItem* control() const = 0;
     QVariant valueOfProperty(const QString& propertyName);
-    QQuickItem* singleControl() const;
 };
 
 #endif // REACTPROPERTYTTESTCASE_H

--- a/ReactQt/tests/reacttestcase.cpp
+++ b/ReactQt/tests/reacttestcase.cpp
@@ -59,6 +59,31 @@ RootView* ReactTestCase::rootView() const {
     return reactView;
 }
 
+QQuickItem* ReactTestCase::topJSComponent() const {
+    // Even when in JS we have only one <Image> component returned in render(),
+    // it is wrapped in <View> component implicitly, so we have hierarchy in QML:
+    // ReactView
+    //  |-<View>
+    //    |-<Image>
+
+    QList<QQuickItem*> reactViewChilds = rootView()->childItems();
+    Q_ASSERT(reactViewChilds.count() == 1);
+
+    QQuickItem* view = reactViewChilds[0];
+    QList<QQuickItem*> viewChilds = view->childItems();
+    Q_ASSERT(viewChilds.count() == 1);
+
+    QQuickItem* control = viewChilds[0];
+    Q_ASSERT(control);
+
+    return control;
+}
+
+QVariant ReactTestCase::valueOfControlProperty(QQuickItem* control, const QString& propertyName) {
+    Q_ASSERT(control);
+    return control->property(propertyName.toStdString().c_str());
+}
+
 ReactBridge* ReactTestCase::bridge() {
     ReactBridge* bridge = rootView()->bridge();
     Q_ASSERT(bridge);

--- a/ReactQt/tests/reacttestcase.h
+++ b/ReactQt/tests/reacttestcase.h
@@ -41,6 +41,8 @@ protected:
     void waitAndVerifyJsAppStarted();
     void waitAndVerifyJSException(const QString& exceptionMessage);
     void waitAndVerifyCondition(std::function<bool()> condition, const QString& timeoutMessage);
+    QQuickItem* topJSComponent() const;
+    QVariant valueOfControlProperty(QQuickItem* control, const QString& propertyName);
 
 private:
     void registerReactQtTypes();

--- a/ReactQt/tests/resources.qrc
+++ b/ReactQt/tests/resources.qrc
@@ -5,5 +5,6 @@
         <file>TestActivityIndicatorProps.qml</file>
         <file>TestButtonProps.qml</file>
         <file>TestSliderProps.qml</file>
+        <file>TestButtonSize.qml</file>
     </qresource>
 </RCC>

--- a/ReactQt/tests/test-button-props.cpp
+++ b/ReactQt/tests/test-button-props.cpp
@@ -30,7 +30,7 @@ protected:
 };
 
 QQuickItem* TestButtonProps::control() const {
-    return singleControl();
+    return topJSComponent();
 }
 
 void TestButtonProps::initTestCase() {

--- a/ReactQt/tests/test-button-size.cpp
+++ b/ReactQt/tests/test-button-size.cpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <QSignalSpy>
+#include <QTest>
+#include <QtQuick/QQuickView>
+
+#include "layout/flexbox.h"
+#include "reactbridge.h"
+#include "reactredboxitem.h"
+#include "reacttestcase.h"
+#include "reacttestmodule.h"
+
+class TestButtonSize : public ReactTestCase {
+    Q_OBJECT
+
+private slots:
+
+    virtual void initTestCase() override;
+    CLEANUP_TEST_CASE_DEFAULT(ReactTestCase)
+
+    void testButtonShouldBeVisible();
+};
+
+void TestButtonSize::initTestCase() {
+    ReactTestCase::initTestCase();
+    loadQML(QUrl("qrc:/TestButtonSize.qml"));
+    showView();
+    waitAndVerifyJsAppStarted();
+}
+
+void TestButtonSize::testButtonShouldBeVisible() {
+    QQuickItem* topView = topJSComponent();
+    QCOMPARE(valueOfControlProperty(topView, "objectName").toString(), QString("TopView"));
+
+    QQuickItem* contentView = topView->childItems().at(0);
+    QCOMPARE(valueOfControlProperty(contentView, "objectName").toString(), QString("Content"));
+
+    QQuickItem* buttonView = contentView->childItems().at(0);
+    QCOMPARE(valueOfControlProperty(buttonView, "objectName").toString(), QString("TestButton"));
+
+    auto buttonFlexbox = Flexbox::findFlexbox(buttonView);
+    Q_ASSERT(buttonFlexbox);
+    waitAndVerifyCondition([=]() { return !buttonFlexbox->isDirty(); }, "Flexbox wasn't recalculated");
+
+    QVERIFY2(buttonView->width() > 0, "Incorrect button width");
+    QVERIFY2(buttonView->height() > 0, "Incorrect button height");
+}
+
+QTEST_MAIN(TestButtonSize)
+#include "test-button-size.moc"

--- a/ReactQt/tests/test-image-props.cpp
+++ b/ReactQt/tests/test-image-props.cpp
@@ -30,7 +30,7 @@ protected:
 };
 
 QQuickItem* TestImageProps::control() const {
-    return singleControl();
+    return topJSComponent();
 }
 
 void TestImageProps::initTestCase() {

--- a/ReactQt/tests/test-slider-props.cpp
+++ b/ReactQt/tests/test-slider-props.cpp
@@ -27,7 +27,7 @@ protected:
 };
 
 QQuickItem* TestSliderProps::control() const {
-    return singleControl();
+    return topJSComponent();
 }
 
 void TestSliderProps::initTestCase() {


### PR DESCRIPTION
Before this commit `Button` implementation had 2 flexboxes - one for enclosing `Button` and one for internal `Text`. 
It appeared that there is a case when `Yoga` nodes calculated in a way, when internal node has nonzero width and height, but external node has width or height equal to 0. Such scenario in `Button` implementation led to the situation when `Text` of the button is visible, but `Button` itself - not.
This pull request fixes the issue by removing second flexbox from `Button` and making its minimal width and height dependent on internal `Text` size.
Also testcase added to prevent bug reappearing in a future.
 