### PR TITLE
Refs #116 Implemented basic Picker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
           sudo apt-get -qy update
           sudo apt-get install -y dbus xvfb curl cmake mesa-common-dev \
-              qt59base qt59graphicaleffects qt59quickcontrols2 qt59declarative 
+              qt59base qt59graphicaleffects qt59quickcontrols2 qt59declarative  qt59x11extras  qt59quickcontrols
           echo "/opt/qt59/bin/qt59-env.sh" >> ~/.circlerc
 
       # Install node

--- a/Libraries/Components/Picker/Picker.js
+++ b/Libraries/Components/Picker/Picker.js
@@ -15,6 +15,7 @@
 var ColorPropType = require('ColorPropType');
 var PickerIOS = require('PickerIOS');
 var PickerAndroid = require('PickerAndroid');
+var PickerUbuntu = require('PickerUbuntu');
 var Platform = require('Platform');
 var React = require('React');
 const PropTypes = require('prop-types');
@@ -162,6 +163,8 @@ class Picker extends React.Component {
      } else if (Platform.OS === 'android') {
        // $FlowFixMe found when converting React.createClass to ES6
        return <PickerAndroid {...this.props}>{this.props.children}</PickerAndroid>;
+     } else if (Platform.OS === 'ubuntu') {
+       return <PickerUbuntu {...this.props}>{this.props.children}</PickerUbuntu>;
      } else {
        return <UnimplementedView />;
      }

--- a/Libraries/Components/Picker/PickerUbuntu.ubuntu.js
+++ b/Libraries/Components/Picker/PickerUbuntu.ubuntu.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule PickerUbuntu
+ * @flow
+ */
+
+'use strict';
+
+var ColorPropType = require('ColorPropType');
+var React = require('React');
+var ReactPropTypes = require('prop-types');
+var StyleSheet = require('StyleSheet');
+var StyleSheetPropType = require('StyleSheetPropType');
+const ViewPropTypes = require('ViewPropTypes');
+var ViewStylePropTypes = require('ViewStylePropTypes');
+
+var requireNativeComponent = require('requireNativeComponent');
+
+var REF_PICKER = 'picker';
+var MODE_DROPDOWN = 'dropdown';
+
+var pickerStyleType = StyleSheetPropType({
+  ...ViewStylePropTypes,
+  color: ColorPropType,
+});
+
+type Event = Object;
+
+/**
+ * Not exposed as a public API - use <Picker> instead.
+ */
+class PickerUbuntu extends React.Component {
+  props: {
+    style?: $FlowFixMe,
+    selectedValue?: any,
+    enabled?: boolean,
+    mode?: 'dialog' | 'dropdown',
+    onValueChange?: Function,
+    prompt?: string,
+    testID?: string,
+  };
+
+  state: *;
+
+  static propTypes = {
+    ...ViewPropTypes,
+    style: pickerStyleType,
+    selectedValue: ReactPropTypes.any,
+    enabled: ReactPropTypes.bool,
+    mode: ReactPropTypes.oneOf(['dialog', 'dropdown']),
+    onValueChange: ReactPropTypes.func,
+    prompt: ReactPropTypes.string,
+    testID: ReactPropTypes.string,
+  };
+
+  constructor(props, context) {
+    super(props, context);
+    var state = this._stateFromProps(props);
+
+    this.state = {
+      ...state,
+      initialSelectedIndex: state.selectedIndex,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(this._stateFromProps(nextProps));
+  }
+
+  // Translate prop and children into stuff that the native picker understands.
+  _stateFromProps = (props) => {
+    var selectedIndex = 0;
+    const items = React.Children.map(props.children, (child, index) => {
+      if (child.props.value === props.selectedValue) {
+        selectedIndex = index;
+      }
+      const childProps = {
+        value: child.props.value,
+        label: child.props.label,
+        color: child.props.color
+      };
+      return childProps;
+    });
+    return {selectedIndex, items};
+  };
+
+  render() {
+    var Picker = UbuntuPicker //this.props.mode === MODE_DROPDOWN ? DropdownPicker : DialogPicker;
+    var nativeProps = {
+      enabled: this.props.enabled,
+      items: this.state.items,
+      mode: this.props.mode,
+      onValueChange: this._onChange,
+      prompt: this.props.prompt,
+      selected: this.state.initialSelectedIndex,
+      testID: this.props.testID,
+      style: [styles.pickerUbuntu, this.props.style],
+      accessibilityLabel: this.props.accessibilityLabel,
+    };
+
+    return <Picker ref={REF_PICKER} {...nativeProps} />;
+  }
+
+  _onChange = (event: Event) => {
+    if (this.props.onValueChange) {
+      var position = event.nativeEvent.position;
+      if (position >= 0) {
+        var children = React.Children.toArray(this.props.children);
+        var value = children[position].props.value;
+        this.props.onValueChange(value, position);
+      } else {
+        this.props.onValueChange(null, position);
+      }
+    }
+    this._lastNativePosition = event.nativeEvent.position;
+    this.forceUpdate();
+  };
+
+  componentDidMount() {
+    this._lastNativePosition = this.state.initialSelectedIndex;
+  }
+
+  componentDidUpdate() {
+    // The picker is a controlled component. This means we expect the
+    // on*Change handlers to be in charge of updating our
+    // `selectedValue` prop. That way they can also
+    // disallow/undo/mutate the selection of certain values. In other
+    // words, the embedder of this component should be the source of
+    // truth, not the native component.
+    if (this.refs[REF_PICKER] && this.state.selectedIndex !== this._lastNativePosition) {
+      this.refs[REF_PICKER].setNativeProps({selected: this.state.selectedIndex});
+      this._lastNativePosition = this.state.selectedIndex;
+    }
+  }
+}
+
+var styles = StyleSheet.create({
+  pickerUbuntu: {
+    // The picker will conform to whatever width is given, but we do
+    // have to set the component's height explicitly on the
+    // surrounding view to ensure it gets rendered.
+    // TODO would be better to export a native constant for this,
+    // like in iOS the RCTDatePickerManager.m
+    height: 50,
+  },
+});
+
+var cfg = {
+  nativeOnly: {
+    items: true,
+    selected: true,
+  }
+};
+
+//var DropdownPicker = requireNativeComponent('AndroidDropdownPicker', PickerAndroid, cfg);
+//var DialogPicker = requireNativeComponent('AndroidDialogPicker', PickerAndroid, cfg);
+//var UbuntuPicker = requireNativeComponent('RCTPickerView', Picker, cfg);
+var UbuntuPicker = requireNativeComponent('RCTPickerView');
+
+module.exports = PickerUbuntu;

--- a/RNTester/js/PickerExample.ubuntu.js
+++ b/RNTester/js/PickerExample.ubuntu.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const React = require('react');
+const ReactNative = require('react-native');
+const StyleSheet = require('StyleSheet');
+const RNTesterBlock = require('RNTesterBlock');
+const RNTesterPage = require('RNTesterPage');
+
+const {
+  Picker,
+  Text,
+} = ReactNative;
+
+const Item = Picker.Item;
+
+class PickerExample extends React.Component {
+  static title = '<Picker>';
+
+  state = {
+    selectedValue: "",
+    selectedIndex: ""
+  };
+
+  render() {
+    return (
+      <RNTesterPage title="<Picker>">
+        <RNTesterBlock title="Basic Picker">
+          <Picker
+            style={styles.picker}
+            selectedValue="red"
+            onValueChange={ (val, pos) => {
+                const newState = {};
+                newState["selectedValue"] = val;
+                newState["selectedIndex"] = pos;
+                this.setState(newState);
+            }}>
+            <Item label="red" color="red" value="red" />
+            <Item label="green" color="green" value="green" />
+            <Item label="blue" color="blue" value="blue" />
+            <Item label="grey" color="grey" value="grey" />
+          </Picker>
+          <Text>
+             Value: {this.state.selectedValue}
+          </Text>
+          <Text>
+             Index: {this.state.selectedIndex}
+          </Text>
+        </RNTesterBlock>
+      </RNTesterPage>
+    );
+  }
+}
+
+var styles = StyleSheet.create({
+  picker: {
+    width: 100,
+    height: 200
+  },
+});
+
+module.exports = PickerExample;

--- a/RNTester/js/RNTesterApp.ubuntu.js
+++ b/RNTester/js/RNTesterApp.ubuntu.js
@@ -65,9 +65,9 @@ class RNTesterApp extends React.Component {
   }
 
   componentDidMount() {
-    let action = RNTesterActions.ExampleAction('TouchableExample');
+    let action = RNTesterActions.ExampleAction('PickerExample');
     const newState = RNTesterNavigationReducer({
-      openExample: 'TouchableExample',
+      openExample: 'PickerExample',
     }, action);
     this.setState(
       newState,

--- a/RNTester/js/RNTesterList.ubuntu.js
+++ b/RNTester/js/RNTesterList.ubuntu.js
@@ -48,6 +48,10 @@ const ComponentExamples: Array<RNTesterExample> = [
   {
     key: 'TouchableExample',
     module: require('./TouchableExample'),
+  },
+  {
+    key: 'PickerExample',
+    module: require('./PickerExample'),
   }
 ];
 

--- a/ReactQt/runtime/src/CMakeLists.txt
+++ b/ReactQt/runtime/src/CMakeLists.txt
@@ -56,6 +56,7 @@ set(
   componentmanagers/textinputmanager.cpp
   componentmanagers/imagemanager.cpp
   componentmanagers/imageloader.cpp
+  componentmanagers/pickermanager.cpp
   layout/flexbox.cpp
   utilities.cpp
   ../../../ReactCommon/yoga/yoga/Yoga.c

--- a/ReactQt/runtime/src/bridge.cpp
+++ b/ReactQt/runtime/src/bridge.cpp
@@ -38,6 +38,7 @@
 #include "componentmanagers/imagemanager.h"
 #include "componentmanagers/modalmanager.h"
 #include "componentmanagers/navigatormanager.h"
+#include "componentmanagers/pickermanager.h"
 #include "componentmanagers/rawtextmanager.h"
 #include "componentmanagers/scrollviewmanager.h"
 #include "componentmanagers/slidermanager.h"
@@ -49,6 +50,7 @@
 #include "exceptionsmanager.h"
 #include "netinfo.h"
 #include "networking.h"
+
 #include "redboxitem.h"
 #include "testmodule.h"
 #include "timing.h"
@@ -74,27 +76,26 @@ public:
     QMap<int, ModuleData*> modules;
 
     QObjectList internalModules() {
-        return QObjectList{
-            new Timing,
-            new AppState,
-            new AsyncLocalStorage,
-            new Networking,
-            new NetInfo,
-            new DeviceInfo,
-            new BlobProvider,
-            new ViewManager,
-            new RawTextManager,
-            new TextManager,
-            new ImageManager,
-            new ExceptionsManager,
-            new ScrollViewManager,
-            new NavigatorManager,
-            new ActivityIndicatorManager,
-            new TextInputManager,
-            new ButtonManager,
-            new SliderManager,
-            new ModalManager,
-        };
+        return QObjectList{new Timing,
+                           new AppState,
+                           new AsyncLocalStorage,
+                           new Networking,
+                           new NetInfo,
+                           new DeviceInfo,
+                           new BlobProvider,
+                           new ViewManager,
+                           new RawTextManager,
+                           new TextManager,
+                           new ImageManager,
+                           new ExceptionsManager,
+                           new ScrollViewManager,
+                           new NavigatorManager,
+                           new ActivityIndicatorManager,
+                           new TextInputManager,
+                           new ButtonManager,
+                           new SliderManager,
+                           new ModalManager,
+                           new PickerManager};
     }
 };
 

--- a/ReactQt/runtime/src/componentmanagers/pickermanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/pickermanager.cpp
@@ -1,0 +1,66 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <QQmlComponent>
+#include <QQmlProperty>
+#include <QQuickItem>
+#include <QString>
+#include <QVariant>
+
+#include <QDebug>
+
+#include "attachedproperties.h"
+#include "bridge.h"
+#include "pickermanager.h"
+#include "propertyhandler.h"
+#include "utilities.h"
+
+const QString EVENT_ON_VALUE_CHANGE = "onValueChange";
+
+class PickerManagerPrivate {};
+
+PickerManager::PickerManager(QObject* parent) : ViewManager(parent), d_ptr(new PickerManagerPrivate) {}
+
+PickerManager::~PickerManager() {}
+
+ViewManager* PickerManager::viewManager() {
+    return this;
+}
+
+QString PickerManager::moduleName() {
+    return "RCTPickerViewManager";
+}
+
+QString PickerManager::qmlComponentFile() const {
+    return "qrc:/qml/ReactPicker.qml";
+}
+
+void PickerManager::configureView(QQuickItem* view) const {
+    ViewManager::configureView(view);
+    view->setProperty("pickerManager", QVariant::fromValue((QObject*)this));
+}
+
+QStringList PickerManager::customDirectEventTypes() {
+    return QStringList{EVENT_ON_VALUE_CHANGE};
+}
+
+bool PickerManager::shouldLayout() const {
+    return true;
+}
+
+void PickerManager::sendValueChangeToJs(QQuickItem* picker, int index) {
+    if (!picker)
+        return;
+
+    notifyJsAboutEvent(tag(picker), EVENT_ON_VALUE_CHANGE, QVariantMap{{"target", tag(picker)}, {"position", index}});
+}
+
+#include "pickermanager.moc"

--- a/ReactQt/runtime/src/componentmanagers/pickermanager.h
+++ b/ReactQt/runtime/src/componentmanagers/pickermanager.h
@@ -1,0 +1,45 @@
+
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#ifndef PICKERMANAGER_H
+#define PICKERMANAGER_H
+
+#include "viewmanager.h"
+
+class PropertyHandler;
+class PickerManagerPrivate;
+class PickerManager : public ViewManager {
+    Q_OBJECT
+    Q_INTERFACES(ModuleInterface)
+    Q_DECLARE_PRIVATE(PickerManager)
+
+public:
+    PickerManager(QObject* parent = 0);
+    virtual ~PickerManager();
+
+    virtual ViewManager* viewManager() override;
+    virtual QString moduleName() override;
+
+    virtual QStringList customDirectEventTypes() override;
+    virtual bool shouldLayout() const override;
+
+public slots:
+    void sendValueChangeToJs(QQuickItem* picker, int index);
+
+private:
+    virtual QString qmlComponentFile() const override;
+    virtual void configureView(QQuickItem* view) const override;
+
+private:
+    QScopedPointer<PickerManagerPrivate> d_ptr;
+};
+
+#endif // PICKERMANAGER_H

--- a/ReactQt/runtime/src/qml/ReactPicker.qml
+++ b/ReactQt/runtime/src/qml/ReactPicker.qml
@@ -1,0 +1,46 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.2
+import React 0.1 as React
+import QtQuick.Extras 1.4
+import QtQuick.Controls.Styles 1.2
+
+
+Tumbler {
+    id: tumbler
+    property var pickerManager: null
+    property variant flexbox: React.Flexbox {control: tumbler}
+    property variant p_items: []
+    property int p_selected:0
+    property bool p_onValueChange: false
+    property string p_testID
+
+    objectName: p_testID
+
+    TumblerColumn {
+        model: p_items
+        onCurrentIndexChanged: {
+            if (pickerManager) {
+                pickerManager.sendValueChangeToJs(tumbler, currentIndex);
+            }
+        }
+    }
+
+    style: TumblerStyle {
+        id: tumblerStyle
+
+        delegate: Item {
+            implicitHeight: (tumbler.height - padding.top - padding.bottom) / tumblerStyle.visibleItemCount
+            Text {
+                id: label
+                text: styleData.value.label
+                color: styleData.value.color ? styleData.value.color : "black"
+                opacity: 0.4 + Math.max(0, 1 - Math.abs(styleData.displacement)) * 0.6
+                anchors.centerIn: parent
+            }
+        }
+    }
+
+    onP_selectedChanged: {
+        tumbler.setCurrentIndexAt(0, p_selected);
+    }
+}

--- a/ReactQt/runtime/src/qml/ReactPicker.qml
+++ b/ReactQt/runtime/src/qml/ReactPicker.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.7
+import QtQuick 2.9
 import QtQuick.Controls 2.2
 import React 0.1 as React
 import QtQuick.Extras 1.4

--- a/ReactQt/runtime/src/react_resources.qrc
+++ b/ReactQt/runtime/src/react_resources.qrc
@@ -14,5 +14,6 @@
         <file>qml/ReactTextInput.qml</file>
         <file>js/utils.js</file>
         <file>qml/ReactModal.qml</file>
+        <file>qml/ReactPicker.qml</file>
     </qresource>
 </RCC>

--- a/ReactQt/tests/CMakeLists.txt
+++ b/ReactQt/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(REACT_TESTCASE_JS
   JS/TestButtonSize.js
   JS/TestModalProps.js
   JS/TestTextInputProps.js
+  JS/TestPickerProps.js
 )
 
 set(
@@ -45,6 +46,7 @@ add_executable(test-button-props test-button-props.cpp resources.qrc ${REACT_TES
 add_executable(test-button-size test-button-size.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 add_executable(test-modal-props test-modal-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 add_executable(test-textinput-props test-textinput-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
+add_executable(test-picker-props test-picker-props.cpp resources.qrc ${REACT_TESTCASE_SRC} ${REACT_TESTCASE_JS})
 
 
 add_test(test-integration test-integration)
@@ -55,6 +57,7 @@ add_test(test-button-props test-button-props)
 add_test(test-button-size test-button-size)
 add_test(test-modal-props test-modal-props)
 add_test(test-textinput-props test-textinput-props)
+add_test(test-picker-props test-picker-props)
 
 target_link_libraries(test-integration ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-image-props ${REACT_TESTCASE_LIBRARIES})
@@ -64,6 +67,7 @@ target_link_libraries(test-button-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-button-size ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-modal-props ${REACT_TESTCASE_LIBRARIES})
 target_link_libraries(test-textinput-props ${REACT_TESTCASE_LIBRARIES})
+target_link_libraries(test-picker-props ${REACT_TESTCASE_LIBRARIES})
 
 set_target_properties(
   test-integration

--- a/ReactQt/tests/JS/TestPickerProps.js
+++ b/ReactQt/tests/JS/TestPickerProps.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import {
+  AppRegistry,
+  Picker
+} from 'react-native';
+
+const StyleSheet = require('StyleSheet');
+const Item = Picker.Item;
+
+export default class PickerReactNative extends Component {
+  render() {
+    return (
+        <Picker 
+           style={styles.picker} 
+           testID="picker"
+           selectedValue="green"
+           onValueChange={(val, pos) => console.log("Picker.onValueChange()")} 
+         >
+           <Item label="red" value="red" />
+           <Item label="green" value="green" />
+        </Picker>
+    );
+  }
+}
+
+var styles = StyleSheet.create({
+  picker: {
+    width: 100,
+    height: 200
+  },
+});
+
+AppRegistry.registerComponent('TestPickerProps', () => PickerReactNative)
+
+

--- a/ReactQt/tests/TestPickerProps.qml
+++ b/ReactQt/tests/TestPickerProps.qml
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+import QtQuick 2.4
+import React 0.1 as React
+
+Rectangle {
+    id: root
+    width: 640; height: 480;
+
+    React.RootView {
+        objectName: "rootView"
+        anchors.fill: parent
+
+        moduleName: "TestPickerProps"
+        codeLocation: "http://localhost:8081/ReactQt/tests/JS/TestPickerProps.bundle?platform=ubuntu&dev=true"
+    }
+}

--- a/ReactQt/tests/resources.qrc
+++ b/ReactQt/tests/resources.qrc
@@ -8,5 +8,6 @@
         <file>TestButtonSize.qml</file>
         <file>TestModalProps.qml</file>
         <file>TestTextInputProps.qml</file>
+        <file>TestPickerProps.qml</file>
     </qresource>
 </RCC>

--- a/ReactQt/tests/test-picker-props.cpp
+++ b/ReactQt/tests/test-picker-props.cpp
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "reactpropertytestcase.h"
+
+#include <QDebug>
+#include <QTest>
+#include <QtQuick/QQuickView>
+
+class TestPickerProps : public ReactPropertyTestCase {
+    Q_OBJECT
+
+private slots:
+
+    virtual void initTestCase() override;
+
+protected:
+    virtual QQuickItem* control() const override;
+    virtual QVariantMap propValues() const override;
+};
+
+QQuickItem* TestPickerProps::control() const {
+    return topJSComponent();
+}
+
+void TestPickerProps::initTestCase() {
+    ReactPropertyTestCase::initTestCase();
+    loadQML(QUrl("qrc:/TestPickerProps.qml"));
+    waitAndVerifyJsAppStarted();
+}
+
+QVariantMap TestPickerProps::propValues() const {
+    QVariantList items;
+    items.append(QVariantMap{{"label", "red"}, {"value", "red"}});
+    items.append(QVariantMap{{"label", "green"}, {"value", "green"}});
+
+    return {{"p_testID", "picker"}, {"p_onValueChange", true}, {"p_selected", 1}, {"p_items", items}};
+}
+
+QTEST_MAIN(TestPickerProps)
+#include "test-picker-props.moc"

--- a/docs/ReactQt/ComponentsSupport.md
+++ b/docs/ReactQt/ComponentsSupport.md
@@ -11,7 +11,7 @@
 | ListView                    |           | +              |                 | ListView QML Type              | complex    |
 | Modal                       |           | +              | +/-             | Dialog QML Type                | medium     |
 | NavigatorIOS                | ?         |                |                 |                                |            |
-| Picker                      |           | +              |                 | Tumbler or Combobox QML Type   | medium     |
+| Picker                      |           | +              | +/-             | Tumbler QML Type               | medium     |
 | PickerIOS                   |           |                |                 |                                |            |
 | ProgressBarAndroid          |           |                |                 |                                |            |
 | ProgressViewIOS             |           |                |                 |                                |            |


### PR DESCRIPTION
added props unit test

Note: 
In android Picker has two types - dialog and dropdown (iOS seems to have one). 
Here added one type based on QML Tumbler