### PR TITLE
refs #117 - Repair generation and compilation of custom react-native app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,9 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
 
-      - run: npm install
+      - run: |
+          rm -rf ./node_modules/metro-bundler
+          npm install
 
       # Apply metro-bundler patch to add ubuntu platform
       - run: patch --verbose -d ./node_modules/metro-bundler/src -i ../../../add-ubuntu-platform.patch

--- a/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -298,7 +298,7 @@ describe('promise tasks', () => {
 
   it('resolves async tasks recusively before other queued tasks', () => {
     return new Promise(bigAsyncTest);
-  });
+  }, 20000);
 
   it('should also work with a deadline', () => {
     InteractionManager.setDeadline(100);

--- a/ReactQt/CMakeLists.txt
+++ b/ReactQt/CMakeLists.txt
@@ -7,5 +7,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 include_directories(runtime/src)
+set (APP_NAME "ReactNativeApp")
+add_subdirectory(application)
 add_subdirectory(runtime)
 add_subdirectory(tests)

--- a/ReactQt/application/src/main.cpp
+++ b/ReactQt/application/src/main.cpp
@@ -13,12 +13,10 @@
 #include <QQuickView>
 #include <QUrl>
 
-#include "reactattachedproperties.h"
-#include "reactflexlayout.h"
+#include "attachedproperties.h"
 #include "reactitem.h"
-#include "reactrawtextproperties.h"
-#include "reacttextproperties.h"
-#include "reactview.h"
+#include "rootview.h"
+#include "utilities.h"
 
 // TODO: some way to change while running
 class ReactNativeProperties : public QObject {
@@ -116,26 +114,16 @@ private:
     QString m_packagerTemplate = "http://%1:%2/index.ubuntu.bundle?platform=ubuntu&dev=true";
     QUrl m_codeLocation;
     QString m_pluginsPath;
-    QString m_executor = "ReactPipeExecutor";
+    QString m_executor = "NetExecutor";
 };
-
-void registerTypes() {
-    qmlRegisterUncreatableType<ReactAttachedProperties>(
-        "React", 0, 1, "React", "React is not meant to be created directly");
-    qmlRegisterUncreatableType<ReactFlexLayout>("React", 0, 1, "Flex", "Flex is not meant to be created directly");
-    qmlRegisterUncreatableType<ReactTextProperties>("React", 0, 1, "Text", "Text is not meant to be created directly");
-    qmlRegisterUncreatableType<ReactRawTextProperties>(
-        "React", 0, 1, "RawText", "Text is not meant to be created directly");
-    qmlRegisterType<ReactItem>("React", 0, 1, "Item");
-    qmlRegisterType<ReactView>("React", 0, 1, "RootView");
-}
 
 int main(int argc, char** argv) {
     QGuiApplication app(argc, argv);
+    Q_INIT_RESOURCE(react_resources);
     QQuickView view;
     ReactNativeProperties* rnp = new ReactNativeProperties(&view);
 
-    registerTypes();
+    utilities::registerReactTypes();
 
     QCommandLineParser p;
     p.setApplicationDescription("React Native host application");

--- a/ReactQt/application/src/main.qml
+++ b/ReactQt/application/src/main.qml
@@ -1,0 +1,28 @@
+
+/**
+ * Copyright (C) 2016, Canonical Ltd.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import QtQuick 2.4
+import React 0.1 as React
+
+Rectangle {
+  id: root
+  width: 384
+  height: 640
+
+  React.RootView {
+    anchors.fill: parent
+    liveReload: ReactNativeProperties.liveReload
+
+    moduleName: "ReactNativeApp"
+    codeLocation: ReactNativeProperties.codeLocation
+    pluginsPath: ReactNativeProperties.pluginsPath
+    executor: ReactNativeProperties.executor
+  }
+}

--- a/ReactQt/runtime/src/componentmanagers/activityindicatormanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/activityindicatormanager.cpp
@@ -39,7 +39,7 @@ QString ActivityIndicatorManager::moduleName() {
 }
 
 QString ActivityIndicatorManager::qmlComponentFile() const {
-    return ":/qml/ReactActivityIndicator.qml";
+    return "qrc:/qml/ReactActivityIndicator.qml";
 }
 
 #include "activityindicatormanager.moc"

--- a/ReactQt/runtime/src/componentmanagers/buttonmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/buttonmanager.cpp
@@ -70,7 +70,7 @@ void ButtonManager::sendPressedNotificationToJs(QQuickItem* button) {
 }
 
 QString ButtonManager::qmlComponentFile() const {
-    return ":/qml/ReactButton.qml";
+    return "qrc:/qml/ReactButton.qml";
 }
 
 void ButtonManager::configureView(QQuickItem* button) const {

--- a/ReactQt/runtime/src/componentmanagers/imagemanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/imagemanager.cpp
@@ -98,7 +98,7 @@ void ImageManager::configureView(QQuickItem* view) const {
 }
 
 QString ImageManager::qmlComponentFile() const {
-    return ":/qml/ReactImage.qml";
+    return "qrc:/qml/ReactImage.qml";
 }
 
 bool ImageManagerPrivate::isBase64ImageUrl(const QUrl& url) const {

--- a/ReactQt/runtime/src/componentmanagers/modalmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/modalmanager.cpp
@@ -71,7 +71,7 @@ void ModalManager::configureView(QQuickItem* modal) const {
 }
 
 QString ModalManager::qmlComponentFile() const {
-    return ":/qml/ReactModal.qml";
+    return "qrc:/qml/ReactModal.qml";
 }
 
 #include "modalmanager.moc"

--- a/ReactQt/runtime/src/componentmanagers/navigatormanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/navigatormanager.cpp
@@ -88,7 +88,7 @@ void NavigatorManager::configureView(QQuickItem* view) const {
 }
 
 QString NavigatorManager::qmlComponentFile() const {
-    return ":/qml/ReactNavigator.qml";
+    return "qrc:/qml/ReactNavigator.qml";
 }
 
 #define _R_ARG(argn) QGenericArgument(argn.typeName(), argn.data())

--- a/ReactQt/runtime/src/componentmanagers/rawtextmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/rawtextmanager.cpp
@@ -43,5 +43,5 @@ void RawTextManager::configureView(QQuickItem* view) const {
 }
 
 QString RawTextManager::qmlComponentFile() const {
-    return ":/qml/ReactRawText.qml";
+    return "qrc:/qml/ReactRawText.qml";
 }

--- a/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/scrollviewmanager.cpp
@@ -143,7 +143,7 @@ void ScrollViewManager::configureView(QQuickItem* view) const {
 }
 
 QString ScrollViewManager::qmlComponentFile() const {
-    return ":/qml/ReactScrollView.qml";
+    return "qrc:/qml/ReactScrollView.qml";
 }
 
 #include "scrollviewmanager.moc"

--- a/ReactQt/runtime/src/componentmanagers/slidermanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/slidermanager.cpp
@@ -65,7 +65,7 @@ void SliderManager::sendSlidingCompleteToJs(QQuickItem* slider) {
 }
 
 QString SliderManager::qmlComponentFile() const {
-    return ":/qml/ReactSlider.qml";
+    return "qrc:/qml/ReactSlider.qml";
 }
 
 void SliderManager::configureView(QQuickItem* view) const {

--- a/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textinputmanager.cpp
@@ -41,7 +41,7 @@ QString TextInputManager::moduleName() {
 }
 
 QString TextInputManager::qmlComponentFile() const {
-    return ":/qml/ReactTextInput.qml";
+    return "qrc:/qml/ReactTextInput.qml";
 }
 
 void TextInputManager::configureView(QQuickItem* view) const {

--- a/ReactQt/runtime/src/componentmanagers/textmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/textmanager.cpp
@@ -51,7 +51,7 @@ bool TextManager::shouldLayout() const {
 }
 
 QString TextManager::qmlComponentFile() const {
-    return ":/qml/ReactText.qml";
+    return "qrc:/qml/ReactText.qml";
 }
 
 void TextManager::configureView(QQuickItem* view) const {

--- a/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
+++ b/ReactQt/runtime/src/componentmanagers/viewmanager.cpp
@@ -115,7 +115,7 @@ void ViewManager::configureView(QQuickItem* view) const {
 }
 
 QString ViewManager::qmlComponentFile() const {
-    return ":/qml/ReactView.qml";
+    return "qrc:/qml/ReactView.qml";
 }
 
 void ViewManager::notifyJsAboutEvent(int senderTag, const QString& eventName, const QVariantMap& eventData) const {
@@ -136,7 +136,7 @@ int ViewManager::tag(QQuickItem* view) const {
 QQuickItem* ViewManager::createView() const {
     QQmlComponent component(m_bridge->qmlEngine());
     auto file = qmlComponentFile();
-    component.loadUrl(QUrl::fromLocalFile(file));
+    component.loadUrl(QUrl(file));
     if (!component.isReady()) {
         qCritical() << QString("Component for %1 is not ready!").arg(qmlComponentFile()) << component.errors();
         return nullptr;

--- a/ReactQt/runtime/src/redboxitem.cpp
+++ b/ReactQt/runtime/src/redboxitem.cpp
@@ -78,7 +78,7 @@ public:
     void createRedboxItem(QQuickItem* parent) {
 
         QQmlComponent component(bridge->qmlEngine());
-        component.loadUrl(QUrl::fromLocalFile(":/qml/ReactRedboxItem.qml"));
+        component.loadUrl(QUrl("qrc:/qml/ReactRedboxItem.qml"));
         redbox = qobject_cast<QQuickItem*>(component.create());
         if (redbox == nullptr) {
             qCritical() << __PRETTY_FUNCTION__ << "Unable to create RedboxItem" << component.errors();

--- a/local-cli/commands.js
+++ b/local-cli/commands.js
@@ -39,6 +39,7 @@ const documentedCommands = [
   require('./server/server'),
   require('./runIOS/runIOS'),
   require('./runAndroid/runAndroid'),
+  require('./ubuntu/genUbuntu'),
   require('./ubuntu/runUbuntu'),
   require('./library/library'),
   require('./bundle/bundle'),

--- a/local-cli/generator-utils.js
+++ b/local-cli/generator-utils.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+function copyAndReplace(src, dest, replacements) {
+  if (fs.lstatSync(src).isDirectory()) {
+    if (!fs.existsSync(dest)) {
+      fs.mkdirSync(dest);
+    }
+  } else {
+    var content = fs.readFileSync(src, 'utf8');
+    Object.keys(replacements).forEach(function(regex) {
+      content = content.replace(new RegExp(regex, 'gm'), replacements[regex]);
+    });
+    fs.writeFileSync(dest, content);
+  }
+}
+
+function walk(current) {
+  if (!fs.lstatSync(current).isDirectory()) {
+    return [current];
+  }
+
+  var files = fs.readdirSync(current).map(function(child) {
+    child = path.join(current, child);
+    return walk(child);
+  });
+  return [].concat.apply([current], files);
+}
+
+function validatePackageName(name) {
+  if (!name.match(/^[$A-Z_][0-9A-Z_$]*$/i)) {
+    console.error(
+      '"%s" is not a valid name for a project. Please use a valid identifier ' +
+        'name (alphanumeric).',
+      name
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  copyAndReplace: copyAndReplace,
+  walk: walk,
+  validatePackageName: validatePackageName
+};

--- a/local-cli/generator/index.js
+++ b/local-cli/generator/index.js
@@ -65,18 +65,6 @@ module.exports = yeoman.generators.NamedBase.extend({
       }
     );
 
-    this.fs.copy(
-      this.templatePath('_gitignore'),
-      this.destinationPath('.gitignore')
-    );
-    this.fs.copy(
-      this.templatePath('_watchmanconfig'),
-      this.destinationPath('.watchmanconfig')
-    );
-    this.fs.copy(
-      this.templatePath('_buckconfig'),
-      this.destinationPath('.buckconfig')
-    );
   },
 
   writing: function() {

--- a/local-cli/ubuntu/genUbuntu.js
+++ b/local-cli/ubuntu/genUbuntu.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Status Research and Development GmbH.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const fs = require('fs');
+var generate = require('../generate/generate');
+const { exec } = require('child_process');
+
+function applyUbuntuPlatformPatch() {
+  exec('pwd && patch --verbose -d ./node_modules/metro-bundler/src -i ../../react-native/add-ubuntu-platform.patch', (err, stdout, stderr) => {
+    console.log(`Std output: ${stdout}`);
+    if (err) {
+      console.error(`exec error: ${err}`);
+      return;
+    }
+  });
+}
+
+function genUbuntu(args, config) {
+  applyUbuntuPlatformPatch();
+  return generate([
+    '--platform', 'ubuntu',
+    '--project-path', process.cwd(),
+    '--project-name', JSON.parse(
+      fs.readFileSync('package.json', 'utf8')
+    ).name
+  ], config);
+}
+
+module.exports = {
+  name: 'ubuntu',
+  description: 'generates an Ubuntu project for your app',
+  func: genUbuntu
+};

--- a/local-cli/ubuntu/runUbuntu.js
+++ b/local-cli/ubuntu/runUbuntu.js
@@ -51,8 +51,9 @@ function _runUbuntu(args, config) {
       } else {
         // result == 'not_running'
         console.log(chalk.bold('Starting JS server...'));
-        startServerInNewWindow();
+        startPackagerInNewWindow();
       }
+      startUbuntuServerInNewWindow();
       actuallyRun(args, reject);
     }));
   });
@@ -85,9 +86,16 @@ function actuallyRun(args, reject) {
   }
 }
 
-function startServerInNewWindow() {
-  const packagerPath = path.resolve(__dirname, '..', '..', 'packager', 'packager.sh');
-  child_process.spawn('gnome-terminal',['-e', packagerPath],{detached: true});
+function startPackagerInNewWindow() {
+  child_process.spawn('gnome-terminal',['-e', 'npm start'],{detached: true});
 }
 
-module.exports = runUbuntu;
+function startUbuntuServerInNewWindow() {
+  child_process.spawn('gnome-terminal', ['-e', 'node ./ubuntu/bin/ubuntu-server.js'],{detached: true});
+}
+
+module.exports = {
+  name: 'run-ubuntu',
+  description: 'builds and runs your app as native application',
+  func: runUbuntu
+};

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "android",
     "ReactQt",
     "ubuntu-server.js",
+    "add-ubuntu-platform.patch",
     "cli.js",
     "flow",
     "init.sh",
@@ -210,7 +211,9 @@
     "xmldoc": "^0.4.0",
     "xpipe": "^1.0.5",
     "xtend": ">=4.0.0 <4.1.0-0",
-    "yargs": "^6.4.0"
+    "yargs": "^6.4.0",
+    "yeoman-environment": "^1.2.7",
+    "yeoman-generator": "^0.20.3"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",

--- a/react-native-cli/index.js
+++ b/react-native-cli/index.js
@@ -248,6 +248,7 @@ function createProject(name, options) {
       start: 'node node_modules/react-native/local-cli/cli.js start',
       ios: 'react-native run-ios',
       android: 'react-native run-android',
+      ubuntu: 'react-native run-ubuntu'
     }
   };
   fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));
@@ -257,7 +258,7 @@ function createProject(name, options) {
 }
 
 function getInstallPackage(rnPackage) {
-  var packageToInstall = 'https://github.com/status-im/react-native-linux#react-native-qt'
+  var packageToInstall = 'https://github.com/MaxRis/react-native-qt#bug/repair-run-ubuntu-#117';
   var isValidSemver = semver.valid(rnPackage);
   if (isValidSemver) {
     packageToInstall = 'react-native@' + isValidSemver;


### PR DESCRIPTION
- Custom react-native application (file path ReactQt/application/src) is added as subdirectory to main cmake build file. Compilation of it should help to avoid future compilation issues of custom apps on significant source code updates.
- Custom app uses `Q_INIT_RESOURCE(react_resources);` to force linking of resources from react-native library http://doc.qt.io/qt-5/qdir.html#Q_INIT_RESOURCE
- Repaired creation of custom react-native app with running of commands (react-native-cli from our repo should be installed globally): 1. `react-native init ProjectName` 2. `cd ProjectName` 3. `react-native ubuntu` 4. `react-native run-ubuntu` . Old generation mechanism is restored with minor changes and tweaks ( commands description updated, automatic start of `node ubuntu-server.js`, automatic applying of patch to extend metro-bundler with `ubuntu` platform ).
- Resources references changed to URLs with `qrc:` at the start for consistency across the project. Please let me know if you are fine with it.